### PR TITLE
Fix character literal handling in parenthesis checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bin/agent-lisp-paren-aid-linux
 bin/agent-lisp-paren-aid-darwin-amd64
 bin/agent-lisp-paren-aid-darwin-arm64
 bin/agent-lisp-paren-aid-deno
+.\#CLAUDE.md

--- a/checker.go
+++ b/checker.go
@@ -48,6 +48,20 @@ func CheckParentheses(data string, filePath string) string {
 				break // Ignore the rest of the line
 			}
 
+			// Handle character literals (e.g., ?a, ?\n, ?\))
+			if char == '?' && j+1 < len(line) {
+				j++ // Skip the '?'
+				nextChar := line[j]
+				if nextChar == '\\' && j+1 < len(line) {
+					// Escaped character literal (e.g., ?\n, ?\))
+					j += 2 // Skip '\' and the following character
+				} else {
+					// Simple character literal (e.g., ?a)
+					j++ // Skip the character
+				}
+				continue
+			}
+
 			switch char {
 			case '"':
 				inString = true

--- a/checker_test.go
+++ b/checker_test.go
@@ -151,3 +151,14 @@ func TestIssue10(t *testing.T) {
 		t.Errorf("Expected '%s', got '%s'", expected, result)
 	}
 }
+
+func TestCharLiteralBalanced(t *testing.T) {
+	lispCode, err := loadFixture("char-literal-balanced.el")
+	if err != nil {
+		t.Fatalf("Failed to load fixture: %v", err)
+	}
+	result := CheckParentheses(lispCode, "")
+	if result != "ok" {
+		t.Errorf("Expected 'ok', got '%s'", result)
+	}
+}

--- a/tests/fixtures/char-literal-balanced.el
+++ b/tests/fixtures/char-literal-balanced.el
@@ -1,0 +1,12 @@
+;; Test for character literal handling
+(defun test ()
+  (cond
+   ((and (string= (buffer-name) "*scratch*")
+         (char-equal (preceding-char) ?\)))
+    (eval-print-last-sexp))
+   ((eq (preceding-char) ?\()
+    (message "opening paren"))
+   ((eq (preceding-char) ?\n)
+    (message "newline"))
+   (t
+    (message "other"))))


### PR DESCRIPTION
The parenthesis checker was incorrectly counting closing parentheses within Emacs Lisp character literals (e.g., ?\), ?\(, ?\n) as actual closing parentheses, leading to false positive "extra closing parentheses" errors.

Added proper handling for character literals:
- Detect character literals starting with '?'
- Skip escaped character literals (?\n, ?\), etc.)
- Skip simple character literals (?a, ?b, etc.)

Also added test case to verify character literal handling works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)